### PR TITLE
Add PyPy support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,8 @@ env:
     - TOXENV=py27
     - TOXENV=py33
     - TOXENV=py34
-#   PyPy support needs cleanup of doctests, plus some help from zope.security.
-#   - TOXENV=pypy
-#   - TOXENV=pypy3
+    - TOXENV=pypy
+    - TOXENV=pypy3
 install:
     - travis_retry pip install tox
 script:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Changes
 - Allow short-circuit traversal for non-proxied dict subclasses.  See:
   https://github.com/zopefoundation/zope.pagetemplate/pull/3 .
 
+- Add support for PyPy.
 
 4.1.0 (2014-12-27)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ TESTS_REQUIRE = [
 
 
 setup(name='zope.pagetemplate',
-      version='4.1.1.dev0',
+      version='4.1.2.dev0',
       author='Zope Foundation and Contributors',
       author_email='zope-dev@zope.org',
       description='Zope Page Templates',
@@ -99,9 +99,7 @@ setup(name='zope.pagetemplate',
           'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: Implementation :: CPython',
-#          PyPy support needs cleanup of doctests, plus some help from
-#          zope.security.
-#         'Programming Language :: Python :: Implementation :: PyPy',
+          'Programming Language :: Python :: Implementation :: PyPy',
           'Natural Language :: English',
           'Operating System :: OS Independent',
           'Topic :: Internet :: WWW/HTTP',

--- a/src/zope/pagetemplate/engine.py
+++ b/src/zope/pagetemplate/engine.py
@@ -171,7 +171,7 @@ class ZopeContext(ZopeContextBase):
         ...
         >>> zc = ZopeContext(ExpressionEngine, {})
         >>> out = zc.evaluateMacro(expression)
-        >>> out.__class__
+        >>> type(out)
         <type 'list'>
 
         The method does some trivial checking to make sure we are getting

--- a/src/zope/pagetemplate/tests/test_engine.py
+++ b/src/zope/pagetemplate/tests/test_engine.py
@@ -94,6 +94,9 @@ def test_suite():
         (re.compile(r"<class 'zope.security._proxy._Proxy'>"),
          "<type 'zope.security._proxy._Proxy'>"),
         (re.compile(r"<class 'list'>"), "<type 'list'>"),
+        # PyPy/pure-Python implementation
+        (re.compile(r"<class 'zope.security.proxy.ProxyPy'>"),
+        "<type 'zope.security._proxy._Proxy'>"),
     ])
 
     suite = unittest.TestSuite()

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 envlist =
-#   PyPy support needs cleanup of doctests, plus some help from zope.security.
-#   py26,py27,py33,py34,pypy,pypy3
-    py26,py27,py33,py34
+    py26,py27,py33,py34,pypy,pypy3
 
 [testenv]
 deps =


### PR DESCRIPTION
PyPy doesn't support assigning to `__builtins__`, even in `eval`, so
this means that zope.untrusted.builtins is not helpful, even though it
can be installed. Therefore, `HAVE_UNTRUSTED` must always be False under
PyPy, just like under Python 3. (I wonder if that deserves a mention in the changelog or other documentation?)

Minor doctest renormalization to deal with the changed class name of the proxy.

A pure-Python proxy can't lie about its type, so use `__class__` in one doctest.

Since these were only test changes, I've currently left the version change in the last digit.