### PR TITLE
Add Python 3.6, drop Python 3.3

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[run]
+source = zope.pagetemplate
+
+[report]
+precision = 2
+exclude_lines =
+    pragma: no cover
+    if __name__ == '__main__':
+    raise NotImplementedError
+    self.fail
+    raise AssertionError

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ develop-eggs/
 eggs/
 parts/
 dist/
+.coverage
+htmlcov/
+docs/_build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,20 @@
 language: python
 sudo: false
 python:
-  - 2.7
-  - 3.3
-  - 3.4
-  - 3.5
-  - pypy
-  - pypy3
+    - 2.7
+    - 3.4
+    - 3.5
+    - 3.6
+    - pypy
+    - pypy3.5-5.8.0
 install:
-  - pip install tox-travis
+    - pip install -U pip setuptools
+    - pip install -U coverage coveralls
+    - pip install -U -e .[test]
 script:
-  - tox
+    - coverage run -m zope.testrunner --test-path=src
+after_success:
+    - coveralls
 notifications:
     email: false
+cache: pip

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,20 +1,21 @@
-Changes
-=======
+=========
+ Changes
+=========
 
 4.3.0 (unreleased)
-------------------
+==================
 
-- Add support for Python 3.5.
+- Add support for Python 3.5 and 3.6.
 
-- Drop support for Python 2.6 and 3.2.
+- Drop support for Python 2.6, 3.2 and 3.3.
 
 4.2.1 (2015-06-06)
-------------------
+==================
 
 - Add support for Python 3.2.
 
 4.2.0 (2015-06-02)
-------------------
+==================
 
 - Allow short-circuit traversal for non-proxied dict subclasses.  See:
   https://github.com/zopefoundation/zope.pagetemplate/pull/3 .
@@ -22,28 +23,28 @@ Changes
 - Add support for PyPy / PyPy3.
 
 4.1.0 (2014-12-27)
-------------------
+==================
 
 - Add support for Python 3.4.
 
 - Add support for testing on Travis.
 
 4.0.4 (2013-03-15)
-------------------
+==================
 
 - Ensure that ``ZopePythonExpr`` and ``PythonExpr`` are separate classes even
   when ``zope.untrustedpython`` is not available.  Fixes a ZCML conflict error
   in ``zope.app.pagetemplate``.
 
 4.0.3 (2013-02-28)
-------------------
+==================
 
 - Only allow ``zope.untrustedpython`` to be a dependency in Python 2.
 
 - Fix buildout to work properly.
 
 4.0.2 (2013-02-22)
-------------------
+==================
 
 - Migrate from ``zope.security.untrustedpython`` to ``zope.untrustedpython``.
 
@@ -54,14 +55,14 @@ Changes
 - Add support for Python 3.3.
 
 4.0.1 (2012-01-23)
-------------------
+==================
 
 - LP#732972:  PageTemplateTracebackSupplement no longer passes
   ``check_macro_expansion=False`` to old templates which do not
   accept this argument.
 
 4.0.0 (2012-12-13)
-------------------
+==================
 
 - Replace deprecated ``zope.interface.classProvides`` usage with equivalent
   ``zope.interface.provider`` decorator.
@@ -78,12 +79,12 @@ Changes
   avoid LP#732972.
 
 3.6.3 (2011-09-21)
-------------------
+==================
 
 - Fix test assertions to be compatible with ``zope.tal`` 3.6.
 
 3.6.2 (2011-09-21)
-------------------
+==================
 
 - Change interface for engine and program such that the return type of
   the ``cook`` method is a tuple ``(program, macros)``. This follows
@@ -93,12 +94,12 @@ Changes
   ``_v_macros`` volatile attribute which was missing.
 
 3.6.1 (2011-08-23)
-------------------
+==================
 
 - Fix issue with missing default value for ``strictinsert``.
 
 3.6.0 (2011-08-20)
-------------------
+==================
 
 - Replace StringIO stream class with a faster list-based implementation.
 
@@ -108,14 +109,14 @@ Changes
 - Remove ancient copyright from test files (LP: #607228)
 
 3.5.2 (2010-07-08)
-------------------
+==================
 
 - Fix ``PTRuntimeError`` exception messages to be consistent across Python
   versions, and compatibile with the output under Python 2.4.  (More
   readable than the previous output under Python 2.6 as well.)
 
 3.5.1 (2010-04-30)
-------------------
+==================
 
 - Remove use of ``zope.testing.doctestunit`` in favor of stdlib's doctest.
 
@@ -123,7 +124,7 @@ Changes
   module uses it.
 
 3.5.0 (2009-05-25)
-------------------
+==================
 
 - Add test coverage reporting support.
 
@@ -131,7 +132,7 @@ Changes
   ``zope.app.pagetemplate`` package.
 
 3.4.2 (2009-03-17)
-------------------
+==================
 
 - Remove old zpkg-related DEPENDENCIES.cfg file.
 
@@ -141,19 +142,19 @@ Changes
 - Change `cheeseshop` to `pypi` in the packages' homepage url.
 
 3.4.1 (2009-01-27)
-------------------
+==================
 
 - Fix test due to recent changes in zope.tal.
 
 
 3.4.0 (2007-10-02)
-------------------
+==================
 
 - Initial release independent of the Zope 3 tree.
 
 
 3.2.0 (2006-01-05)
-------------------
+==================
 
 - Corresponds to the version of the zope.pagetemplate package shipped
   as part of the Zope 3.2.0 release.
@@ -166,7 +167,7 @@ Changes
 
 
 3.1.0 (2005-10-03)
-------------------
+==================
 
 - Corresponds to the version of the zope.pagetemplate package shipped
   as part of the Zope 3.1.0 release.
@@ -178,7 +179,7 @@ Changes
 
 
 3.0.0 (2004-11-07)
-------------------
+==================
 
 - Corresponds to the version of the zope.pagetemplate package shipped
   as part of the Zope X3.0.0 release.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,7 @@ include *.txt
 include bootstrap.py
 include buildout.cfg
 include tox.ini
+include .travis.yml
+include .coveragerc
+
 recursive-include src *.txt *.html *.pt

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,21 @@
-``zope.pagetemplate``
-=====================
+=======================
+ ``zope.pagetemplate``
+=======================
+
+.. image:: https://img.shields.io/pypi/v/zope.pagetemplate.svg
+        :target: https://pypi.python.org/pypi/zope.pagetemplate/
+        :alt: Latest release
+
+.. image:: https://img.shields.io/pypi/pyversions/zope.pagetemplate.svg
+        :target: https://pypi.org/project/zope.pagetemplate/
+        :alt: Supported Python versions
 
 .. image:: https://travis-ci.org/zopefoundation/zope.pagetemplate.png?branch=master
         :target: https://travis-ci.org/zopefoundation/zope.pagetemplate
+
+.. image:: https://coveralls.io/repos/github/zopefoundation/zope.pagetemplate/badge.svg?branch=master
+        :target: https://coveralls.io/github/zopefoundation/zope.pagetemplate?branch=master
+
 
 Page Templates provide an elegant templating mechanism that achieves a
 clean separation of presentation and application logic while allowing

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -19,54 +19,20 @@
 """Setup for zope.pagetemplate package
 """
 import os
-import sys
 from setuptools import setup, find_packages
-
-PY3 = sys.version_info[0] >= 3
 
 
 def read(*rnames):
     with open(os.path.join(os.path.dirname(__file__), *rnames)) as f:
         return f.read()
 
-def _modname(path, base, name=''):
-    if path == base:
-        return name
-    dirname, basename = os.path.split(path)
-    return _modname(dirname, base, basename + '.' + name)
-
-def alltests():
-    import logging
-    import pkg_resources
-    import unittest
-
-    class NullHandler(logging.Handler):
-        level = 50
-
-        def emit(self, record):
-            pass
-
-    logging.getLogger().addHandler(NullHandler())
-
-    suite = unittest.TestSuite()
-    base = pkg_resources.working_set.find(
-        pkg_resources.Requirement.parse('zope.pagetemplate')).location
-    for dirpath, dirnames, filenames in os.walk(base):
-        if os.path.basename(dirpath) == 'tests':
-            for filename in filenames:
-                if ( filename.endswith('.py') and
-                     filename.startswith('test') ):
-                    mod = __import__(
-                        _modname(dirpath, base, os.path.splitext(filename)[0]),
-                        {}, {}, ['*'])
-                    suite.addTest(mod.test_suite())
-    return suite
 
 TESTS_REQUIRE = [
-    'zope.testing',
     'zope.proxy',
     'zope.security',
-] + (['zope.untrustedpython'] if not PY3 else [])
+    'zope.testing',
+    'zope.testrunner',
+]
 
 
 setup(name='zope.pagetemplate',
@@ -77,8 +43,9 @@ setup(name='zope.pagetemplate',
       long_description=(
           read('README.rst')
           + '\n\n' +
+          '======================\n'
           'Detailed Documentation\n' +
-          '----------------------'
+          '======================'
           + '\n\n' +
           read('src', 'zope', 'pagetemplate', 'architecture.txt')
           + '\n\n' +
@@ -95,36 +62,44 @@ setup(name='zope.pagetemplate',
           'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.3',
           'Programming Language :: Python :: 3.4',
           'Programming Language :: Python :: 3.5',
+          'Programming Language :: Python :: 3.6',
           'Programming Language :: Python :: Implementation :: CPython',
           'Programming Language :: Python :: Implementation :: PyPy',
           'Natural Language :: English',
           'Operating System :: OS Independent',
           'Topic :: Internet :: WWW/HTTP',
-          'Framework :: Zope3'],
-      url='http://pypi.python.org/pypi/zope.pagetemplate',
+          'Framework :: Zope3',
+      ],
+      url='http://github.com/zopefoundation/zope.pagetemplate',
       license='ZPL 2.1',
       packages=find_packages('src'),
       package_dir={'': 'src'},
       namespace_packages=['zope'],
-      extras_require=dict(
-          test=TESTS_REQUIRE,
-          untrusted=['zope.untrustedpython'] if not PY3 else [],
-      ),
-      install_requires=['setuptools',
-                        'six',
-                        'zope.interface',
-                        'zope.component',
-                        'zope.tales',
-                        'zope.tal >= 4.2.0',
-                        'zope.i18n >= 4.0.1',
-                        'zope.i18nmessageid',
-                        'zope.traversing',
-                       ],
+      extras_require={
+          'test': TESTS_REQUIRE,
+          'test:python_version == "2.7"': [
+              'zope.untrustedpython',
+          ],
+          'untrusted': [
+          ],
+          'untrusted:python_version == "2.7"': [
+              'zope.untrustedpython',
+          ],
+      },
+      install_requires=[
+          'setuptools',
+          'six',
+          'zope.interface',
+          'zope.component',
+          'zope.tales',
+          'zope.tal >= 4.2.0',
+          'zope.i18n >= 4.0.1',
+          'zope.i18nmessageid',
+          'zope.traversing',
+      ],
       include_package_data=True,
       zip_safe=False,
       tests_require=TESTS_REQUIRE,
-      test_suite='__main__.alltests',
-      )
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,26 +1,20 @@
 [tox]
 envlist =
-    py27,py33,py34,py35,pypy,pypy3
+   py27,py34,py35,py36,pypy,pypy3,coverage
 
 [testenv]
-deps =
-    zope.pagetemplate[test]
-    zope.component
-    zope.i18n
-    zope.i18nmessageid
-    zope.interface
-    zope.proxy
-    zope.security
-    zope.tal
-    zope.tales
-    zope.testing
-    zope.testrunner
-    zope.traversing
 commands =
-    python setup.py -q test -q
+    zope-testrunner --test-path=src []
+deps =
+    .[test]
 
-[testenv:py27]
+[testenv:coverage]
+usedevelop = true
+basepython =
+    python2.7
+commands =
+    coverage run -m zope.testrunner --test-path=src []
+    coverage report --fail-under=88
 deps =
     {[testenv]deps}
-    zope.untrustedpython
-    RestrictedPython
+    coverage


### PR DESCRIPTION
- Badges
- Enable coverage reporting and coveralls
  - Less than 100%; see #9
- Enable universal wheels by using environment markers in the dependencies.
- Use zope.testrunner for the NS path issues.

Fixes #10 