### PR TITLE
Point to pagetemplates.rtd.io instead of the zope2 book. 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ Page Templates are based on `a Template Attribute Language
 <https://pypi.python.org/pypi/zope.tal>`_ with expressions provided by
 `TALES <https://pypi.python.org/pypi/zope.tales>`_. For a description
 of their syntax, see `the reference documentation
-<https://zope.readthedocs.io/en/latest/zope2book/AppendixC.html>`_.
+<https://pagetemplates.readthedocs.io/en/latest/>`_.
 
 For detailed documentation on the usage of this package, see
 https://zopepagetemplate.readthedocs.io

--- a/docs/using.rst
+++ b/docs/using.rst
@@ -6,7 +6,7 @@ This document focuses on usage of the Page Templates API.
 
 For information about writing Page Templates documents and using TAL
 and TALES, refer to the `reference documentation
-<https://zope.readthedocs.io/en/latest/zope2book/AppendixC.html>`_ or the
+<https://pagetemplates.readthedocs.io/en/latest/>`_ or the
 `Chameleon documentation
 <https://chameleon.readthedocs.io/en/latest/reference.html>`_ if you
 are using z3c.ptcompat.


### PR DESCRIPTION
See zopefoundation/zope.tal#9