### PR TITLE
Fix tests on PyPy

### DIFF
--- a/src/zope/pagetemplate/engine.py
+++ b/src/zope/pagetemplate/engine.py
@@ -344,7 +344,7 @@ class ZopeEngine(ZopeBaseEngine):
       >>> r = context.evaluate('python: {12: object()}.values')
       >>> str(type(r).__name__) in (
       ...   ('_Proxy',) if HAVE_UNTRUSTED else
-      ...   ('builtin_function_or_method', 'method'))
+      ...   ('builtin_function_or_method', 'method', 'instancemethod'))
       True
 
       >>> r = context.evaluate('python: {12: object()}[12].__class__')


### PR DESCRIPTION
Instance methods have type 'instancemethod' instead of just 'method' on
PyPy2.7 (version 7.0.0 here).

Closes #22.