### PR TITLE
Avoid traceback reference cycle in PageTemplate._cook

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 4.6.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Avoid traceback reference cycle in ``PageTemplate._cook``.
 
 
 4.5.0 (2020-02-10)

--- a/src/zope/pagetemplate/pagetemplate.py
+++ b/src/zope/pagetemplate/pagetemplate.py
@@ -230,10 +230,13 @@ class PageTemplate(object):
                 source_file, self._text, pt_engine, self.content_type)
         except:
             etype, e = sys.exc_info()[:2]
-            self._v_errors = [
-                "Compilation failed",
-                "%s.%s: %s" % (etype.__module__, etype.__name__, e)
-                ]
+            try:
+                self._v_errors = [
+                    "Compilation failed",
+                    "%s.%s: %s" % (etype.__module__, etype.__name__, e)
+                    ]
+            finally:
+                del e
 
         self._v_cooked = 1
 


### PR DESCRIPTION
In Python 3, exceptions have a ``__traceback__`` attribute containing
their associated traceback.  Storing an exception in a local variable of
a frame present in that traceback thus creates a reference cycle.  Avoid
this by explicitly deleting the exception value when we're finished with
it.