### PR TITLE
Switch to PEP 420 native namespace.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
  Changes
 =========
 
-5.3 (unreleased)
+6.0 (unreleased)
 ================
 
 - Nothing changed yet.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@
 6.0 (unreleased)
 ================
 
-- Nothing changed yet.
+- Replace ``pkg_resources`` namespace with PEP 420 native namespace.
 
 
 5.2 (2025-08-06)

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ TESTS_REQUIRE = [
 
 
 setup(name='zope.pagetemplate',
-      version='5.3.dev0',
+      version='6.0.dev0',
       author='Zope Foundation and Contributors',
       author_email='zope-dev@zope.dev',
       description='Zope Page Templates',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@
 """
 import os
 
-from setuptools import find_packages
 from setuptools import setup
 
 
@@ -33,7 +32,7 @@ TESTS_REQUIRE = [
     'zope.proxy',
     'zope.security',
     'zope.testing',
-    'zope.testrunner',
+    'zope.testrunner >= 6.4',
     'zope.untrustedpython >= 5.0.dev0',
 ]
 
@@ -69,9 +68,6 @@ setup(name='zope.pagetemplate',
       ],
       url='https://github.com/zopefoundation/zope.pagetemplate',
       license='ZPL-2.1',
-      packages=find_packages('src'),
-      package_dir={'': 'src'},
-      namespace_packages=['zope'],
       python_requires='>=3.9',
       extras_require={
           'test': TESTS_REQUIRE,

--- a/src/zope/__init__.py
+++ b/src/zope/__init__.py
@@ -1,1 +1,0 @@
-__import__('pkg_resources').declare_namespace(__name__)  # pragma: no cover


### PR DESCRIPTION
- **Bumped version for breaking release.**
- **Replace ``pkg_resources`` namespace with PEP 420 native namespace.**
- **Switch to PEP 420 native namespace.**
